### PR TITLE
Návrh dekretu přes appku - part 1

### DIFF
--- a/app/src/app/app.module.ts
+++ b/app/src/app/app.module.ts
@@ -30,6 +30,7 @@ import { MatTableModule } from '@angular/material';
 import { ProcessingRoundComponent } from './processing-round/processing-round.component';
 import { VotingComponent } from './voting/voting.component';
 import { UnitsComponent } from './units/units.component';
+import { DecretFormComponent } from './decret-form/decret-form.component';
 
 @NgModule({
   declarations: [
@@ -45,7 +46,8 @@ import { UnitsComponent } from './units/units.component';
     DelegateNameComponent,
     ProcessingRoundComponent,
     VotingComponent,
-    UnitsComponent
+    UnitsComponent,
+    DecretFormComponent
   ],
   imports: [
     BrowserModule,

--- a/app/src/app/decret-form/decret-form.component.css
+++ b/app/src/app/decret-form/decret-form.component.css
@@ -1,0 +1,19 @@
+
+.questionDescription {
+    margin: 0;
+}
+
+mat-form-field {
+    width:100%;
+}
+
+.question {
+    width: 350px;
+}
+
+.state {
+    text-align: right;
+    color: grey;
+    padding-bottom: 3px;
+    padding-right: 5px;
+}

--- a/app/src/app/decret-form/decret-form.component.html
+++ b/app/src/app/decret-form/decret-form.component.html
@@ -1,0 +1,19 @@
+<p><strong>{{title}}</strong></p>
+<mat-card>
+    <form [formGroup]="questionForm" appFireForm [path]="questionsPath" (stateChange)="changeHandler($event)">
+        <mat-form-field class="question">
+            <mat-label>Typ dekretu</mat-label>
+            <mat-select formControlName="questionType">
+                <mat-option *ngFor="let type of allQuestions" [value]="type.value">
+                    {{type.name}}
+                </mat-option>
+            </mat-select>
+        </mat-form-field>
+        <p class="questionDescription">
+            <mat-form-field>
+                <input matInput placeholder="Krátký popis dekretu" type="text" formControlName="name">
+            </mat-form-field>
+        </p>
+    </form>
+    <mat-card-footer class="state mat-small">{{state}}</mat-card-footer>
+</mat-card>

--- a/app/src/app/decret-form/decret-form.component.spec.ts
+++ b/app/src/app/decret-form/decret-form.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DecretFormComponent } from './decret-form.component';
+
+describe('DecretFormComponent', () => {
+  let component: DecretFormComponent;
+  let fixture: ComponentFixture<DecretFormComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ DecretFormComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DecretFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/app/src/app/decret-form/decret-form.component.ts
+++ b/app/src/app/decret-form/decret-form.component.ts
@@ -37,7 +37,7 @@ export class DecretFormComponent implements OnInit {
       questionType: [""],
       name: [""],
       byDelegateId: [this.delegateId],
-      byVotingRight: [""],
+      byVotingRightId: [""],
       roundId: [this.roundId],
       hidden: [false]
     })

--- a/app/src/app/decret-form/decret-form.component.ts
+++ b/app/src/app/decret-form/decret-form.component.ts
@@ -1,0 +1,57 @@
+import { Component, OnInit, Input } from '@angular/core';
+import { FormBuilder, FormGroup } from '@angular/forms';
+import { ALL_QUESTIONS } from '../../../../common/config';
+import { AngularFireDatabase } from '@angular/fire/database';
+import { AngularFireAuth } from '@angular/fire/auth';
+import { MatDialog } from '@angular/material';
+import { VotingRightWithQuestionPath } from '../model';
+
+@Component({
+  selector: 'app-decret-form',
+  templateUrl: './decret-form.component.html',
+  styleUrls: ['./decret-form.component.css']
+})
+export class DecretFormComponent implements OnInit {
+
+  constructor(private fb: FormBuilder, private db: AngularFireDatabase, private auth: AngularFireAuth, private dialog: MatDialog) { }
+
+  questionForm: FormGroup;
+  title: string
+  state: string;
+
+  allQuestions = ALL_QUESTIONS
+
+  @Input()
+  votingRight: VotingRightWithQuestionPath
+
+  @Input()
+  roundId: string
+  
+  @Input()
+  delegateId: string
+
+  questionsPath: string
+
+  ngOnInit() {
+    this.questionForm = this.fb.group({
+      questionType: [""],
+      name: [""],
+      byDelegateId: [this.delegateId],
+      byVotingRight: [""],
+      roundId: [this.roundId],
+      hidden: [false]
+    })
+    this.title = `Návrh dekretu za rod: ${this.votingRight["name"]}`
+    this.questionsPath = this.votingRight["dbPath"]
+  }
+
+  changeHandler(e) {
+    let names = {
+      'loading': "Načítání…",
+      'modified': "Ukládání…",
+      'synced': "Uloženo",
+      'error': "Chyba ukládání!"
+    }
+    this.state = names[e]
+  }
+}

--- a/app/src/app/model.ts
+++ b/app/src/app/model.ts
@@ -52,3 +52,26 @@ export interface Unit {
     visibility: string,
     description: string
 }
+
+export interface VotingRight {
+    id: string,
+    name: string,
+    votes: number
+  }
+
+export interface VotingRightWithQuestionPath extends VotingRight {
+    dbPath: string
+}
+
+export interface Question {
+    name: string,
+    questionType: string,
+    byDelegateId: string,
+    byVotingRight: string,
+    roundId: string,
+    hidden: boolean,
+}
+
+export interface QuestionWithDbPath extends Question {
+    dbPath: string
+}

--- a/app/src/app/model.ts
+++ b/app/src/app/model.ts
@@ -67,7 +67,7 @@ export interface Question {
     name: string,
     questionType: string,
     byDelegateId: string,
-    byVotingRight: string,
+    byVotingRightId: string,
     roundId: string,
     hidden: boolean,
 }

--- a/app/src/app/present-round/present-round.component.html
+++ b/app/src/app/present-round/present-round.component.html
@@ -12,7 +12,7 @@ potřebujete více času, napište na Slacku.)</p>
 <br />
 <app-decret-form *ngFor="let votingRight of controlledVotingRights | async" [votingRight]="votingRight" [roundId]="roundId" [delegateId]="delegateId"></app-decret-form>
 <br />
-<button mat-raised-button color="accent" *ngIf="!(markedQuestionAsSent | async) else questionSent" (click)="sendQuestion()">Odeslat návrh dekretů</button>
+<button mat-raised-button color="accent" *ngIf="!(markedLandsraadQuestionsAsSent | async) else questionSent" (click)="sendQuestion()">Odeslat návrh dekretů</button>
 <ng-template #questionSent>
   <p><strong>Návrh dekretů odeslán</strong></p>
 </ng-template>

--- a/app/src/app/present-round/present-round.component.html
+++ b/app/src/app/present-round/present-round.component.html
@@ -9,3 +9,12 @@
 (Všechny změny v depeši se ukládají automaticky. Kliknutím na "Odeslat depeši" dáváte najevo, že depeše je
 kompletní a může začít vyhodnocování. Můžete vše editovat i po odeslání, ale může se stát že už se na to ve vyhodnocování nebude brát zřetel. Vyhodnocování také začne po deadlinu i pokud jste depeši neodeslali. Pokud
 potřebujete více času, napište na Slacku.)</p>
+<br />
+<app-decret-form *ngFor="let votingRight of controlledVotingRights | async" [votingRight]="votingRight" [roundId]="roundId" [delegateId]="delegateId"></app-decret-form>
+<br />
+<button mat-raised-button color="accent" *ngIf="!(markedQuestionAsSent | async) else questionSent" (click)="sendQuestion()">Odeslat návrh dekretů</button>
+<ng-template #questionSent>
+  <p><strong>Návrh dekretů odeslán</strong></p>
+</ng-template>
+<p>(Změny se ukládají stejně jako v akcích.)</p>
+<br />

--- a/app/src/app/present-round/present-round.component.ts
+++ b/app/src/app/present-round/present-round.component.ts
@@ -21,7 +21,7 @@ export class PresentRoundComponent implements OnInit {
 
   primaryActionPaths: Observable<string[]>
   markedAsSent: Observable<boolean>
-  markedQuestionAsSent: Observable<boolean>
+  markedLandsraadQuestionsAsSent: Observable<boolean>
   controlledVotingRights: Observable<VotingRightWithQuestionPath[]>
   delegateId: string
   delegationId: string
@@ -47,7 +47,7 @@ export class PresentRoundComponent implements OnInit {
         return val as boolean
       })
     )
-    this.markedQuestionAsSent = this.db.object("delegateRounds/" + this.delegateId + "/" + this.roundId + "/markedQuestionAsSent").valueChanges().pipe(
+    this.markedLandsraadQuestionsAsSent = this.db.object("delegateRounds/" + this.delegateId + "/" + this.roundId + "/markedLandsraadQuestionsAsSent").valueChanges().pipe(
       map(val => {
         return val as boolean
       })
@@ -88,6 +88,6 @@ export class PresentRoundComponent implements OnInit {
   }
 
   sendQuestion() {
-    this.db.object("delegateRounds/" + this.delegateId + "/" + this.roundId + "/markedQuestionAsSent").set(true)
+    this.db.object("delegateRounds/" + this.delegateId + "/" + this.roundId + "/markedLandsraadQuestionsAsSent").set(true)
   }
 }

--- a/app/src/app/present-round/present-round.component.ts
+++ b/app/src/app/present-round/present-round.component.ts
@@ -53,9 +53,9 @@ export class PresentRoundComponent implements OnInit {
       })
     )
     this.controlledVotingRights = combineLatest(
-      this.db.list("landsraad/votingRights", ref => ref.orderByChild("controlledBy").equalTo(this.delegateId)).valueChanges(),
+      this.db.list("landsraad/votingRights", ref => ref.orderByChild("controlledBy").equalTo(this.delegateId)).snapshotChanges(),
       this.db.list("landsraad/questions/", ref => ref.orderByChild("byDelegateId").equalTo(this.delegateId)).snapshotChanges(),
-      (votingRights, questionsSnapshots) => {
+      (votingRightsSnapshots, questionsSnapshots) => {
         let questions: QuestionWithDbPath[] = questionsSnapshots.map(
           snapshot => {
           let question = snapshot.payload.val() as Question
@@ -64,11 +64,12 @@ export class PresentRoundComponent implements OnInit {
             dbPath: `landsraad/questions/${snapshot.key}`
           }
         })
-        let votingRightsPath: VotingRightWithQuestionPath[] = votingRights.map(
-          (votingRight: VotingRight) => {
+        let votingRightsPath: VotingRightWithQuestionPath[] = votingRightsSnapshots.map(
+          (votingRightSnapshot) => {
+            let votingRight = votingRightSnapshot.payload.val() as VotingRight
             let questionForVotingRight = questions.find(
               question => {
-                return question["byVotingRight"] === votingRight["name"] && question["roundId"] === this.roundId
+                return question["byVotingRightId"] === votingRightSnapshot.key && question["roundId"] === this.roundId
               })
             if (questionForVotingRight) {
               return {

--- a/app/src/app/voting/voting.component.ts
+++ b/app/src/app/voting/voting.component.ts
@@ -5,6 +5,7 @@ import { NgForm } from '@angular/forms';
 import { combineLatest, Observable } from 'rxjs';
 import { map, take, tap } from 'rxjs/operators';
 import { ValueName } from '../../../../common/config';
+import { VotingRight } from '../model';
 
 @Component({
   selector: 'app-voting',
@@ -173,12 +174,6 @@ export class VotingComponent implements OnInit {
     this.displayedColumns = columns
   }
 
-}
-
-interface VotingRight {
-  id: string,
-  name: string,
-  votes: number
 }
 
 interface GenericFirebaseSnapshotMapping {

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -14,7 +14,7 @@ body { margin: 0;
     flex: 1 1 auto;
 }
 
-.action {
+.action, .question {
     margin-bottom: 1em;
 }
 .tab-content {

--- a/common/config.ts
+++ b/common/config.ts
@@ -78,6 +78,21 @@ export const UNIT_VISIBILITIES: ValueName[] = [
     { value: 'fremen', name: "Fremenská" }
 ]
 
+export const ALL_QUESTIONS: ValueName[] = [
+    { value: "mandat_sardaukaru", name: "Mandát sardaukarů" },
+    { value: "zruseni_mandatu_sardaukaru", name: "Zrušení mandátu sardaukarů" },
+    { value: "vyslani_vojsk_landsraadu", name: "Vyslání vojsk Landsraadu" },
+    { value: "zmena_mandatu_vojsk_landsraadu", name: "Změna mandátu vojsk Landsraadu" },
+    { value: "stazeni_vojska_landsraadu", name: "Stažení vojsk Landsraadu" },
+    { value: "zrizeni_vysetrovaci_komise", name: "Zřízení vyšetřovací komise" },
+    { value: "prerozdeleni_podilu_choam", name: "Přerozdělení podílů CHOAM" },
+    { value: "uvaleni_embarga", name: "Uvalení embarga" },
+    { value: "zruseni_embarga", name: "Zrušení embarga" },
+    { value: "zmena_kvot", name: "Změna kvót" },
+    { value: "jiny", name: "Jiný" },
+    { value: "", name: "- Žádný -" }
+]
+
 export interface ValueName {
     value: string;
     name: string;

--- a/common/config.ts
+++ b/common/config.ts
@@ -93,6 +93,8 @@ export const ALL_QUESTIONS: ValueName[] = [
     { value: "", name: "- Žádný -" }
 ]
 
+export const QUESTION_TYPE_HLAS_LANDSRAADU: ValueName = { value: "hlas_landsradu", name: "Hlas Landsraadu" }
+
 export interface ValueName {
     value: string;
     name: string;

--- a/database-sample-data.json
+++ b/database-sample-data.json
@@ -70,14 +70,14 @@
       "round_1": {
         "delegation": "delegation_id_1",
         "markedAsSent": true,
-        "markedQuestionAsSent": true,
+        "markedLandsraadQuestionsAsSent": true,
         "bv": 30,
         "message": "You are doomed"
       },
       "round_2": {
         "delegation": "delegation_id_1",
         "markedAsSent": true,
-        "markedQuestionAsSent": false
+        "markedLandsraadQuestionsAsSent": false
       }
     }
   },

--- a/database-sample-data.json
+++ b/database-sample-data.json
@@ -143,7 +143,7 @@
         "name": "Deploy Sardaukarů?",
         "questionType": "mandat_sardaukaru",
         "byDelegateId": "delegate_id_1",
-        "byVotingRight": "Harko",
+        "byVotingRightId": "Harko",
         "roundId": "round_id_1",
         "hidden": false
       }

--- a/database-sample-data.json
+++ b/database-sample-data.json
@@ -70,12 +70,14 @@
       "round_1": {
         "delegation": "delegation_id_1",
         "markedAsSent": true,
+        "markedQuestionAsSent": true,
         "bv": 30,
         "message": "You are doomed"
       },
       "round_2": {
         "delegation": "delegation_id_1",
-        "markedAsSent": true
+        "markedAsSent": true,
+        "markedQuestionAsSent": false
       }
     }
   },
@@ -138,8 +140,17 @@
     },
     "questions": {
       "question_id_1": {
-        "name": "Deploy Sardaukarů?"
+        "name": "Deploy Sardaukarů?",
+        "questionType": "mandat_sardaukaru",
+        "byDelegateId": "delegate_id_1",
+        "byVotingRight": "Harko",
+        "roundId": "round_id_1",
+        "hidden": false
       }
+    },
+    "questionsConfig": {
+      "filterByRound": "",
+      "showHiddenQuestions": true
     },
     "answers": {
       "question_id_1": {

--- a/security-rules.bolt
+++ b/security-rules.bolt
@@ -61,7 +61,7 @@ path /delegateRounds {
     write() { isSameDelegate(delegate_id) }
   }
 
-  path /{delegate_id}/{round_id}/markedQuestionAsSent is Boolean {
+  path /{delegate_id}/{round_id}/markedLandsraadQuestionsAsSent is Boolean {
     write() { isSameDelegate(delegate_id) }
   }
 }
@@ -141,7 +141,20 @@ path /landsraad/votingRights {
 
 path /landsraad/questions {
   read() { isSignedIn() }
-  write() { isSignedIn() }
+  write() { isSwiss() }
+  path /{question_id} is Question {
+    read() { isSignedIn() }
+    write() { isSwiss() || (query.orderByChild == "byDelegateId" && query.equalTo == auth.uid) }
+  }
+}
+
+type Question {
+  name: Description | Null,
+  questionType: Keyword | Null,
+  byDelegateId: Id | Null,
+  byVotingRight: Keyword | Null,
+  roundId: Id | Null,
+  hidden: Boolean,
 }
 
 path /landsraad/answers {

--- a/security-rules.bolt
+++ b/security-rules.bolt
@@ -60,6 +60,10 @@ path /delegateRounds {
   path /{delegate_id}/{round_id}/markedAsSent is Boolean {
     write() { isSameDelegate(delegate_id) }
   }
+
+  path /{delegate_id}/{round_id}/markedQuestionAsSent is Boolean {
+    write() { isSameDelegate(delegate_id) }
+  }
 }
 
 //
@@ -137,7 +141,7 @@ path /landsraad/votingRights {
 
 path /landsraad/questions {
   read() { isSignedIn() }
-  write() { isSwiss() }
+  write() { isSignedIn() }
 }
 
 path /landsraad/answers {

--- a/security-rules.bolt
+++ b/security-rules.bolt
@@ -152,7 +152,7 @@ type Question {
   name: Description | Null,
   questionType: Keyword | Null,
   byDelegateId: Id | Null,
-  byVotingRight: Keyword | Null,
+  byVotingRightId: Id | Null,
   roundId: Id | Null,
   hidden: Boolean,
 }

--- a/security-rules.bolt
+++ b/security-rules.bolt
@@ -144,7 +144,7 @@ path /landsraad/questions {
   write() { isSwiss() }
   path /{question_id} is Question {
     read() { isSignedIn() }
-    write() { isSwiss() || (query.orderByChild == "byDelegateId" && query.equalTo == auth.uid) }
+    write() { isSameDelegate(this.byDelegateId) }
   }
 }
 

--- a/swiss/src/app/landsraad/landsraad.component.ts
+++ b/swiss/src/app/landsraad/landsraad.component.ts
@@ -1,8 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import { AngularFireAction, AngularFireDatabase, DatabaseSnapshot } from '@angular/fire/database';
+import { AngularFireDatabase } from '@angular/fire/database';
 import { NgForm } from '@angular/forms';
-import { ngxCsv } from 'ngx-csv';
-import { combineLatest } from 'rxjs';
 import { Observable } from 'rxjs';
 import { flatMap, map, take, tap } from 'rxjs/operators';
 import { ValueName } from '../../../../common/config';
@@ -43,13 +41,20 @@ export class LandsraadComponent implements OnInit {
     this.questionPaths = this.db.list("landsraad/questions").snapshotChanges().pipe(
       map(
         snapshots => {
-          return snapshots.map(snapshot => "landsraad/questions/" + snapshot.key)
+          let snapshotsFiltered = snapshots.filter(snap => {
+            const question = snap.payload.val()
+            // as we now have to fill-in DB object even if no question is selected, filter out "no selected" question
+            return question["questionType"] !== ""
+          })
+          return snapshotsFiltered.map(snapshot => "landsraad/questions/" + snapshot.key)
         })
     )
     this.questions = this.db.list("landsraad/questions").snapshotChanges().pipe(
       map(
         snapshots => {
-          return snapshots.map(snapshot => {
+          return snapshots
+          .filter(snapshot => snapshot.payload.val()["questionType"] !== "")
+          .map(snapshot => {
             return { value: snapshot.key, name: snapshot.payload.val()["name"] }
           }).concat({ value: "", name: "- Žádná -" })
         })
@@ -77,6 +82,7 @@ export class LandsraadComponent implements OnInit {
   addQuestion(form: NgForm) {
     if (form.valid) {
       let ref = this.db.list("landsraad/questions").push({
+        questionType: "Hlas Landsraadu",
         name: form.value["name"]
       });
       (form.value["answers"] as string).split(",").forEach(

--- a/swiss/src/app/landsraad/landsraad.component.ts
+++ b/swiss/src/app/landsraad/landsraad.component.ts
@@ -2,8 +2,8 @@ import { Component, OnInit } from '@angular/core';
 import { AngularFireDatabase } from '@angular/fire/database';
 import { NgForm } from '@angular/forms';
 import { Observable } from 'rxjs';
-import { flatMap, map, take, tap } from 'rxjs/operators';
-import { ValueName } from '../../../../common/config';
+import { flatMap, map } from 'rxjs/operators';
+import { ValueName, QUESTION_TYPE_HLAS_LANDSRAADU } from '../../../../common/config';
 
 @Component({
   selector: 'app-landsraad',
@@ -82,7 +82,7 @@ export class LandsraadComponent implements OnInit {
   addQuestion(form: NgForm) {
     if (form.valid) {
       let ref = this.db.list("landsraad/questions").push({
-        questionType: "Hlas Landsraadu",
+        questionType: QUESTION_TYPE_HLAS_LANDSRAADU["value"],
         name: form.value["name"]
       });
       (form.value["answers"] as string).split(",").forEach(

--- a/swiss/src/app/round-delegate-form/round-delegate-form.component.html
+++ b/swiss/src/app/round-delegate-form/round-delegate-form.component.html
@@ -17,8 +17,8 @@
     </ng-container> | 
     <span class="positive" *ngIf="delegateForm.controls.markedAsSent.value">Depeše odeslána</span>
     <span class="negative" *ngIf="!delegateForm.controls.markedAsSent.value">Depeše neodeslána</span> |
-    <span class="positive" *ngIf="delegateForm.controls.markedQuestionAsSent.value">Dekret odeslán</span>
-    <span class="negative" *ngIf="!delegateForm.controls.markedQuestionAsSent.value">Dekret neodeslán</span>
+    <span class="positive" *ngIf="delegateForm.controls.markedLandsraadQuestionsAsSent.value">Dekrety odeslány</span>
+    <span class="negative" *ngIf="!delegateForm.controls.markedLandsraadQuestionsAsSent.value">Dekrety neodeslány</span>
     <br />
     <mat-form-field class="message">
         <textarea matInput placeholder="Důležitá sdělení vedení" formControlName="message"></textarea>

--- a/swiss/src/app/round-delegate-form/round-delegate-form.component.html
+++ b/swiss/src/app/round-delegate-form/round-delegate-form.component.html
@@ -16,7 +16,9 @@
         BV použito
     </ng-container> | 
     <span class="positive" *ngIf="delegateForm.controls.markedAsSent.value">Depeše odeslána</span>
-    <span class="negative" *ngIf="!delegateForm.controls.markedAsSent.value">Depeše neodeslána</span>
+    <span class="negative" *ngIf="!delegateForm.controls.markedAsSent.value">Depeše neodeslána</span> |
+    <span class="positive" *ngIf="delegateForm.controls.markedQuestionAsSent.value">Dekret odeslán</span>
+    <span class="negative" *ngIf="!delegateForm.controls.markedQuestionAsSent.value">Dekret neodeslán</span>
     <br />
     <mat-form-field class="message">
         <textarea matInput placeholder="Důležitá sdělení vedení" formControlName="message"></textarea>

--- a/swiss/src/app/round-delegate-form/round-delegate-form.component.ts
+++ b/swiss/src/app/round-delegate-form/round-delegate-form.component.ts
@@ -33,7 +33,7 @@ export class RoundDelegateFormComponent implements OnInit {
       delegation: [''],
       mainActions: [0],
       markedAsSent: [false],
-      markedQuestionAsSent: [false],
+      markedLandsraadQuestionsAsSent: [false],
       bv: [0],
       message: ['']
     })

--- a/swiss/src/app/round-delegate-form/round-delegate-form.component.ts
+++ b/swiss/src/app/round-delegate-form/round-delegate-form.component.ts
@@ -33,6 +33,7 @@ export class RoundDelegateFormComponent implements OnInit {
       delegation: [''],
       mainActions: [0],
       markedAsSent: [false],
+      markedQuestionAsSent: [false],
       bv: [0],
       message: ['']
     })

--- a/swiss/src/app/round/round.component.html
+++ b/swiss/src/app/round/round.component.html
@@ -137,5 +137,9 @@
     <button mat-button color="accent" *ngIf="!showingProjects" (click)="showProjects()">Ukázat progress
         misí</button>
 </mat-card>
+<p>Dekrety:</p>
+<mat-card clas="card">
+    <button mat-stroked-button color="accent" (click)="setQuestions()">Nastavit dekrety pro kolo</button>&nbsp;
+</mat-card>
 <br />
 <button mat-stroked-button color="accent" (click)="deleteRound()">Smazat kolo</button>

--- a/swiss/src/app/round/round.component.ts
+++ b/swiss/src/app/round/round.component.ts
@@ -351,18 +351,19 @@ export class RoundComponent implements OnInit {
               )
             ).subscribe()
             // create new questions and answers for each votingRight
-            this.db.list("landsraad/votingRights").valueChanges().pipe(
+            this.db.list("landsraad/votingRights").snapshotChanges().pipe(
               take(1),
               map(
-                votingRights => {
-                  votingRights.forEach(
-                    votingRight => {
+                votingRightsSnapshots => {
+                  votingRightsSnapshots.forEach(
+                    votingRightSnapshot => {
+                      let votingRight = votingRightSnapshot.payload.val()
                       let delegateId = votingRight["controlledBy"]
                       let ref = this.db.list("landsraad/questions/").push({
                         questionType: "",
                         name: "",
                         byDelegateId: delegateId,
-                        byVotingRight: votingRight["name"],
+                        byVotingRightId: votingRightSnapshot.key,
                         roundId: this.roundId,
                         hidden: false
                       })

--- a/swiss/src/app/round/round.component.ts
+++ b/swiss/src/app/round/round.component.ts
@@ -372,7 +372,7 @@ export class RoundComponent implements OnInit {
                           this.db.list(`landsraad/answers/${ref.key}`).push({name: answer.trim()})
                         }
                       )
-                      this.db.object(`delegateRounds/${delegateId}/${this.roundId}/markedQuestionAsSent`).set(false)
+                      this.db.object(`delegateRounds/${delegateId}/${this.roundId}/markedLandsraadQuestionsAsSent`).set(false)
                     }
                   )
                 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -14,7 +14,7 @@ body { margin: 0;
     flex: 1 1 auto;
 }
 
-.action {
+.action, .question {
     margin-bottom: 1em;
 }
 .tab-content {


### PR DESCRIPTION
Co bylo uděláno v tomto PR:
- do uživatelské appky byl přidán komponent na návrh standartního dekretu, spolu s akcemi a tlacitko na generovani prazdnych dekretu pro soucasne kolo
- status o odeslání dekretu zobrazen v admin appce (Kola / hráči)
- kvůli způsobu implementace musíme v admin appce filtrovat dekrety s typem "" protože to znamená že hráči nic nenavrhli

Zbývá do dalších PR:
- filtrování dekretů v admin appce
- návrh "speciálního" dekretu "Bill of particulars" přes appku pokud hráč kontroluje alespoň jeden ne-neutrální rod který má právo volit v Landsraadu
- zobrazování navrhnutého dekretu v "Proběhlém kole" (optional)