### PR TITLE
Navrhovani dekretu v aplikaci - part 2

### DIFF
--- a/common/config.ts
+++ b/common/config.ts
@@ -100,7 +100,7 @@ export interface ValueName {
     name: string;
 }
 
-export interface ValueNameExtended extends ValueName {
+export interface ValueNameWithQuestionType extends ValueName {
     roundId: string;
     hidden: boolean;
     questionType: string;

--- a/common/config.ts
+++ b/common/config.ts
@@ -100,6 +100,12 @@ export interface ValueName {
     name: string;
 }
 
+export interface ValueNameExtended extends ValueName {
+    roundId: string;
+    hidden: boolean;
+    decretType: string;
+}
+
 export function findValueName(rows: ValueName[], value: string) {
     if (value == undefined) return "N/A"
     let row = rows.find((row) => row.value == value)

--- a/common/config.ts
+++ b/common/config.ts
@@ -103,7 +103,7 @@ export interface ValueName {
 export interface ValueNameExtended extends ValueName {
     roundId: string;
     hidden: boolean;
-    decretType: string;
+    questionType: string;
 }
 
 export function findValueName(rows: ValueName[], value: string) {

--- a/security-rules.bolt
+++ b/security-rules.bolt
@@ -177,6 +177,11 @@ path /landsraad/votingConfig {
   write() { isSwiss() }
 }
 
+path /landsraad/questionsConfig {
+  read() { isSignedIn() }
+  write() { isSwiss() }
+}
+
 isControllingVotingRight(voting_right_id) {
   auth.uid == prior(root).landsraad.votingRights[voting_right_id].controlledBy
 }

--- a/security-rules.bolt
+++ b/security-rules.bolt
@@ -164,6 +164,7 @@ path /landsraad/answers {
 
 path /landsraad/votes {
   read() { isSwiss() || isSignedIn() }
+  write() { isSwiss() }
   path /{question_id}/{voting_right_id} {
     delete() { isControllingVotingRight(voting_right_id) }
   }

--- a/security-rules.bolt
+++ b/security-rules.bolt
@@ -179,7 +179,7 @@ path /landsraad/votingConfig {
 }
 
 path /landsraad/questionsConfig {
-  read() { isSignedIn() }
+  read() { isSwiss() || isSignedIn() }
   write() { isSwiss() }
 }
 

--- a/swiss/src/app/landsraad/landsraad.component.css
+++ b/swiss/src/app/landsraad/landsraad.component.css
@@ -24,3 +24,11 @@
     }
 }
 
+.input-question {
+    width: 350px;
+}
+
+.input-answers {
+    width: 100%;
+}
+

--- a/swiss/src/app/landsraad/landsraad.component.css
+++ b/swiss/src/app/landsraad/landsraad.component.css
@@ -9,7 +9,18 @@
     width: 630px;
 }
 
+.filter-by-round {
+    width: 350px;
+}
+
 .basic-checkbox {
     padding: 1.25em;
     padding-left: 2.5em;
 }
+
+.mat-card {
+    button.mat-basic {
+        color: #8c5b08 !important;
+    }
+}
+

--- a/swiss/src/app/landsraad/landsraad.component.html
+++ b/swiss/src/app/landsraad/landsraad.component.html
@@ -45,11 +45,11 @@
     <p>Přidat otázku:</p>
     <mat-card class="card">
         <form (ngSubmit)="addQuestion(addQuestionForm)" #addQuestionForm="ngForm">
-            <mat-form-field class="text">
+            <mat-form-field class="input-question">
                 <input matInput placeholder="Otázka" type="text" name="name" required ngModel>
             </mat-form-field>
             <br />
-            <mat-form-field class="text">
+            <mat-form-field class="input-answers">
                 <input matInput placeholder="Odpovědi oddělené čárkou" type="text" name="answers" required ngModel>
             </mat-form-field>
             <br />

--- a/swiss/src/app/landsraad/landsraad.component.html
+++ b/swiss/src/app/landsraad/landsraad.component.html
@@ -1,7 +1,7 @@
 <div class="tab-content">
     <p>Zobrazené otázky:</p>
     <mat-card>
-        <form [formGroup]="questionsConfig" appFireForm [path]="path">
+        <form [formGroup]="questionsConfig" appFireForm [path]="questionsConfigPath">
             <mat-form-field class="filter-by-round">
                 <mat-label>Filtrovat otázky pro kolo</mat-label>
                 <mat-select formControlName="filterByRound">

--- a/swiss/src/app/landsraad/landsraad.component.html
+++ b/swiss/src/app/landsraad/landsraad.component.html
@@ -1,4 +1,24 @@
 <div class="tab-content">
+    <p>Zobrazené otázky:</p>
+    <mat-card>
+        <form [formGroup]="questionsConfig" appFireForm [path]="path">
+            <mat-form-field class="filter-by-round">
+                <mat-label>Filtrovat otázky pro kolo</mat-label>
+                <mat-select formControlName="filterByRound">
+                    <mat-option *ngFor="let round of rounds | async" [value]="round.value">
+                        {{round.name}}
+                    </mat-option>
+                </mat-select>
+            </mat-form-field>
+            <mat-checkbox class="basic-checkbox" formControlName="showHiddenQuestions">
+                Ukázat schované otázky
+            </mat-checkbox>&nbsp;
+        </form>
+        <ng-container>
+            <span>Otázky které nejsou přiřazené k žádnému kolu (otázky přidané pomocí "Přidat otázku" níže) jsou zobrazeny vždy.</span>
+        </ng-container>
+    </mat-card>
+    <p>Hlasování a výsledky Landsraadu:</p>
     <mat-card class="card">
         <form #currentQuestionForm="ngForm">
             <mat-form-field class="defined-width">
@@ -20,7 +40,7 @@
     </mat-card>
     <p>Otázky:</p>
     <mat-card class="card">
-        <app-question-form *ngFor="let path of questionPaths | async" [path]="path"></app-question-form>
+        <app-question-form *ngFor="let path of questionPaths | async" [path]="path" [delegates]="delegates" [rounds]="rounds"></app-question-form>
     </mat-card>
     <p>Přidat otázku:</p>
     <mat-card class="card">

--- a/swiss/src/app/landsraad/landsraad.component.html
+++ b/swiss/src/app/landsraad/landsraad.component.html
@@ -40,7 +40,7 @@
     </mat-card>
     <p>Otázky:</p>
     <mat-card class="card">
-        <app-question-form *ngFor="let path of questionPaths | async" [path]="path" [delegates]="delegates" [rounds]="rounds"></app-question-form>
+        <app-question-form *ngFor="let path of questionPaths | async" [path]="path" [delegates]="delegates" [votingRights]="votingRights" [rounds]="rounds"></app-question-form>
     </mat-card>
     <p>Přidat otázku:</p>
     <mat-card class="card">

--- a/swiss/src/app/landsraad/landsraad.component.ts
+++ b/swiss/src/app/landsraad/landsraad.component.ts
@@ -76,7 +76,7 @@ export class LandsraadComponent implements OnInit {
             name: question["name"],
             roundId: question["roundId"],
             hidden: question["hidden"],
-            decretType: question["decretType"]
+            questionType: question["questionType"]
           }
         })
         let filteredQuestions: ValueNameExtended[] = questions
@@ -132,8 +132,12 @@ export class LandsraadComponent implements OnInit {
   addQuestion(form: NgForm) {
     if (form.valid) {
       let ref = this.db.list("landsraad/questions").push({
+        name: form.value["name"],
         questionType: QUESTION_TYPE_HLAS_LANDSRAADU["value"],
-        name: form.value["name"]
+        byVotingRightId: "",
+        byDelegateId: "",
+        roundId: "",
+        hidden: false
       });
       (form.value["answers"] as string).split(",").forEach(
         answer => {
@@ -143,6 +147,7 @@ export class LandsraadComponent implements OnInit {
         }
       )
     }
+    // TODO clear out the form for new question
   }
 
   currentQuestionChanged(event) {
@@ -155,8 +160,11 @@ export class LandsraadComponent implements OnInit {
   }
 
   questionEligibleToDisplay(question: ValueNameExtended, showHiddenQuestions: boolean, filterByRoundId: string) {
-    return question["decretType"] !== ""
+    // questionType available
+    return !!question["questionType"]
+    // shown / hidden condition
       && (showHiddenQuestions || !showHiddenQuestions && !question.hidden) 
+    // roundId filtering condition
       && (filterByRoundId === "" || filterByRoundId !== "" && (!question.roundId || question.roundId === filterByRoundId))
   }
 }

--- a/swiss/src/app/landsraad/landsraad.component.ts
+++ b/swiss/src/app/landsraad/landsraad.component.ts
@@ -22,7 +22,7 @@ export class LandsraadComponent implements OnInit {
   resultsShown: Observable<boolean>
   rounds: Observable<ValueName[]>
   filteredRoundSelected: string = ""
-  path: string = "landsraad/questionsConfig"
+  questionsConfigPath: string = "landsraad/questionsConfig"
   questionsConfig: FormGroup
   showHiddenQuestions: Observable<boolean>
   filterByRoundId: Observable<string>
@@ -34,7 +34,7 @@ export class LandsraadComponent implements OnInit {
     this.showHiddenQuestions = this.db.object("landsraad/questionsConfig/showHiddenQuestions").valueChanges() as Observable<boolean>
     this.filterByRoundId = this.db.object("landsraad/questionsConfig/filterByRound").valueChanges() as Observable<string>
     this.questionsConfig = this.fb.group({
-      showHiddenQuestions: [true],
+      showHiddenQuestions: [],
       filterByRound: [""]
     })
     this.delegates = this.db.list("delegates").snapshotChanges().pipe(

--- a/swiss/src/app/landsraad/landsraad.component.ts
+++ b/swiss/src/app/landsraad/landsraad.component.ts
@@ -1,9 +1,17 @@
 import { Component, OnInit } from '@angular/core';
 import { AngularFireDatabase } from '@angular/fire/database';
+<<<<<<< HEAD
 import { NgForm } from '@angular/forms';
 import { Observable } from 'rxjs';
 import { flatMap, map } from 'rxjs/operators';
 import { ValueName, QUESTION_TYPE_HLAS_LANDSRAADU } from '../../../../common/config';
+=======
+import { NgForm, FormBuilder, FormGroup } from '@angular/forms';
+import { combineLatest } from 'rxjs';
+import { Observable } from 'rxjs';
+import { flatMap, map } from 'rxjs/operators';
+import { ValueName, ValueNameExtended } from '../../../../common/config';
+>>>>>>> 3866cd5 (Landsraad UI improvements)
 
 @Component({
   selector: 'app-landsraad',
@@ -20,10 +28,22 @@ export class LandsraadComponent implements OnInit {
   alreadyVotedCount: Observable<number>
   maxVotedCount: Observable<number>
   resultsShown: Observable<boolean>
+  rounds: Observable<ValueName[]>
+  filteredRoundSelected: string = ""
+  path: string = "landsraad/questionsConfig"
+  questionsConfig: FormGroup
+  showHiddenQuestions: Observable<boolean>
+  filterByRoundId: Observable<string>
 
-  constructor(public db: AngularFireDatabase) { }
+  constructor(private fb: FormBuilder, public db: AngularFireDatabase) { }
 
   ngOnInit() {
+    this.showHiddenQuestions = this.db.object("landsraad/questionsConfig/showHiddenQuestions").valueChanges() as Observable<boolean>
+    this.filterByRoundId = this.db.object("landsraad/questionsConfig/filterByRound").valueChanges() as Observable<string>
+    this.questionsConfig = this.fb.group({
+      showHiddenQuestions: [true],
+      filterByRound: [""]
+    })
     this.delegates = this.db.list("delegates").snapshotChanges().pipe(
       map(
         snapshots => {
@@ -38,6 +58,7 @@ export class LandsraadComponent implements OnInit {
           return snapshots.map(snapshot => "landsraad/votingRights/" + snapshot.key)
         })
     )
+<<<<<<< HEAD
     this.questionPaths = this.db.list("landsraad/questions").snapshotChanges().pipe(
       map(
         snapshots => {
@@ -47,8 +68,22 @@ export class LandsraadComponent implements OnInit {
             return question["questionType"] !== ""
           })
           return snapshotsFiltered.map(snapshot => "landsraad/questions/" + snapshot.key)
+=======
+    this.questionPaths = combineLatest(
+      this.db.list("landsraad/questions").snapshotChanges(),
+      this.showHiddenQuestions,
+      this.filterByRoundId,
+      (questionsSnapshots, showHiddenQuestions, filterByRoundId) => {
+        let snapshotsFiltered = questionsSnapshots
+        .filter(snapshot => {
+          let question = snapshot.payload.val() as ValueNameExtended
+          return this.questionEligibleToDisplay(question, showHiddenQuestions, filterByRoundId)
+>>>>>>> 3866cd5 (Landsraad UI improvements)
         })
+        return snapshotsFiltered.map(snapshot => "landsraad/questions/" + snapshot.key)
+      }      
     )
+<<<<<<< HEAD
     this.questions = this.db.list("landsraad/questions").snapshotChanges().pipe(
       map(
         snapshots => {
@@ -57,7 +92,38 @@ export class LandsraadComponent implements OnInit {
           .map(snapshot => {
             return { value: snapshot.key, name: snapshot.payload.val()["name"] }
           }).concat({ value: "", name: "- Žádná -" })
+=======
+
+    this.questions = combineLatest(
+      this.db.list("landsraad/questions").snapshotChanges(),
+      this.showHiddenQuestions,
+      this.filterByRoundId,
+      (questionsSnapshots, showHiddenQuestions, filterByRoundId) => {
+        let questions: ValueNameExtended[] = questionsSnapshots
+        .map(snapshot => {
+          let question = snapshot.payload.val()
+          return {
+            value: snapshot.key, 
+            name: question["name"],
+            roundId: question["roundId"],
+            hidden: question["hidden"],
+            decretType: question["decretType"]
+          }
+>>>>>>> 3866cd5 (Landsraad UI improvements)
         })
+        let filteredQuestions: ValueNameExtended[] = questions
+        .filter(question => {
+          return this.questionEligibleToDisplay(question, showHiddenQuestions, filterByRoundId)
+        })
+        return filteredQuestions
+        .map(question => {
+          return {
+            value: question["value"],
+            name: question["name"]
+          }
+        })
+        .concat({ value: "", name: "- Žádná -" })
+      }
     )
     this.currentQuestion = this.db.object("landsraad/currentQuestion").valueChanges() as Observable<string>
     this.alreadyVotedCount = (this.db.object("landsraad/currentQuestion").valueChanges() as Observable<string>).pipe(flatMap((currentQuestionId, _) => {
@@ -67,6 +133,22 @@ export class LandsraadComponent implements OnInit {
     }))
     this.maxVotedCount = this.votingRightPaths.pipe(map(items => items.length))
     this.resultsShown = this.db.object("landsraad/votingConfig/resultsShown").valueChanges() as Observable<boolean>
+    this.rounds = this.db.list("rounds").snapshotChanges().pipe(
+      map(
+        roundsSnapshots => {
+          let formattedRounds = roundsSnapshots.map(roundRef => {
+            let round = roundRef.payload.val()
+            let key = roundRef.key
+            return {
+              value: key,
+              name: round["name"]
+            }
+          })
+          formattedRounds.push({ value: "", name: "- Žádné -" })
+          return formattedRounds
+        }
+      )
+    )
   }
 
   addVotingRight(form: NgForm) {
@@ -102,5 +184,11 @@ export class LandsraadComponent implements OnInit {
   toggleVotingCheckbox(event) {
     this.resultsShown = event.checked
     this.db.object("landsraad/votingConfig/resultsShown").set(event.checked)
+  }
+
+  questionEligibleToDisplay(question: ValueNameExtended, showHiddenQuestions: boolean, filterByRoundId: string) {
+    return question["decretType"] !== "- Žádný -"
+      && (showHiddenQuestions || !showHiddenQuestions && !question.hidden) 
+      && (filterByRoundId === "" || filterByRoundId !== "" && (!question.roundId || question.roundId === filterByRoundId))
   }
 }

--- a/swiss/src/app/landsraad/landsraad.component.ts
+++ b/swiss/src/app/landsraad/landsraad.component.ts
@@ -1,17 +1,9 @@
 import { Component, OnInit } from '@angular/core';
 import { AngularFireDatabase } from '@angular/fire/database';
-<<<<<<< HEAD
-import { NgForm } from '@angular/forms';
-import { Observable } from 'rxjs';
-import { flatMap, map } from 'rxjs/operators';
-import { ValueName, QUESTION_TYPE_HLAS_LANDSRAADU } from '../../../../common/config';
-=======
 import { NgForm, FormBuilder, FormGroup } from '@angular/forms';
-import { combineLatest } from 'rxjs';
-import { Observable } from 'rxjs';
+import { Observable, combineLatest } from 'rxjs';
 import { flatMap, map } from 'rxjs/operators';
-import { ValueName, ValueNameExtended } from '../../../../common/config';
->>>>>>> 3866cd5 (Landsraad UI improvements)
+import { ValueName, ValueNameExtended, QUESTION_TYPE_HLAS_LANDSRAADU } from '../../../../common/config';
 
 @Component({
   selector: 'app-landsraad',
@@ -58,17 +50,6 @@ export class LandsraadComponent implements OnInit {
           return snapshots.map(snapshot => "landsraad/votingRights/" + snapshot.key)
         })
     )
-<<<<<<< HEAD
-    this.questionPaths = this.db.list("landsraad/questions").snapshotChanges().pipe(
-      map(
-        snapshots => {
-          let snapshotsFiltered = snapshots.filter(snap => {
-            const question = snap.payload.val()
-            // as we now have to fill-in DB object even if no question is selected, filter out "no selected" question
-            return question["questionType"] !== ""
-          })
-          return snapshotsFiltered.map(snapshot => "landsraad/questions/" + snapshot.key)
-=======
     this.questionPaths = combineLatest(
       this.db.list("landsraad/questions").snapshotChanges(),
       this.showHiddenQuestions,
@@ -78,22 +59,10 @@ export class LandsraadComponent implements OnInit {
         .filter(snapshot => {
           let question = snapshot.payload.val() as ValueNameExtended
           return this.questionEligibleToDisplay(question, showHiddenQuestions, filterByRoundId)
->>>>>>> 3866cd5 (Landsraad UI improvements)
         })
         return snapshotsFiltered.map(snapshot => "landsraad/questions/" + snapshot.key)
       }      
     )
-<<<<<<< HEAD
-    this.questions = this.db.list("landsraad/questions").snapshotChanges().pipe(
-      map(
-        snapshots => {
-          return snapshots
-          .filter(snapshot => snapshot.payload.val()["questionType"] !== "")
-          .map(snapshot => {
-            return { value: snapshot.key, name: snapshot.payload.val()["name"] }
-          }).concat({ value: "", name: "- Žádná -" })
-=======
-
     this.questions = combineLatest(
       this.db.list("landsraad/questions").snapshotChanges(),
       this.showHiddenQuestions,
@@ -109,7 +78,6 @@ export class LandsraadComponent implements OnInit {
             hidden: question["hidden"],
             decretType: question["decretType"]
           }
->>>>>>> 3866cd5 (Landsraad UI improvements)
         })
         let filteredQuestions: ValueNameExtended[] = questions
         .filter(question => {
@@ -187,7 +155,7 @@ export class LandsraadComponent implements OnInit {
   }
 
   questionEligibleToDisplay(question: ValueNameExtended, showHiddenQuestions: boolean, filterByRoundId: string) {
-    return question["decretType"] !== "- Žádný -"
+    return question["decretType"] !== ""
       && (showHiddenQuestions || !showHiddenQuestions && !question.hidden) 
       && (filterByRoundId === "" || filterByRoundId !== "" && (!question.roundId || question.roundId === filterByRoundId))
   }

--- a/swiss/src/app/landsraad/landsraad.component.ts
+++ b/swiss/src/app/landsraad/landsraad.component.ts
@@ -3,7 +3,7 @@ import { AngularFireDatabase } from '@angular/fire/database';
 import { NgForm, FormBuilder, FormGroup } from '@angular/forms';
 import { Observable, combineLatest } from 'rxjs';
 import { flatMap, map } from 'rxjs/operators';
-import { ValueName, ValueNameExtended, QUESTION_TYPE_HLAS_LANDSRAADU } from '../../../../common/config';
+import { ValueName, ValueNameWithQuestionType, QUESTION_TYPE_HLAS_LANDSRAADU } from '../../../../common/config';
 
 @Component({
   selector: 'app-landsraad',
@@ -58,7 +58,7 @@ export class LandsraadComponent implements OnInit {
       (questionsSnapshots, showHiddenQuestions, filterByRoundId) => {
         let snapshotsFiltered = questionsSnapshots
         .filter(snapshot => {
-          let question = snapshot.payload.val() as ValueNameExtended
+          let question = snapshot.payload.val() as ValueNameWithQuestionType
           return this.questionEligibleToDisplay(question, showHiddenQuestions, filterByRoundId)
         })
         return snapshotsFiltered.map(snapshot => "landsraad/questions/" + snapshot.key)
@@ -69,7 +69,7 @@ export class LandsraadComponent implements OnInit {
       this.showHiddenQuestions,
       this.filterByRoundId,
       (questionsSnapshots, showHiddenQuestions, filterByRoundId) => {
-        let questions: ValueNameExtended[] = questionsSnapshots
+        let questions: ValueNameWithQuestionType[] = questionsSnapshots
         .map(snapshot => {
           let question = snapshot.payload.val()
           return {
@@ -80,7 +80,7 @@ export class LandsraadComponent implements OnInit {
             questionType: question["questionType"]
           }
         })
-        let filteredQuestions: ValueNameExtended[] = questions
+        let filteredQuestions: ValueNameWithQuestionType[] = questions
         .filter(question => {
           return this.questionEligibleToDisplay(question, showHiddenQuestions, filterByRoundId)
         })
@@ -175,7 +175,7 @@ export class LandsraadComponent implements OnInit {
     this.db.object("landsraad/votingConfig/resultsShown").set(event.checked)
   }
 
-  questionEligibleToDisplay(question: ValueNameExtended, showHiddenQuestions: boolean, filterByRoundId: string) {
+  questionEligibleToDisplay(question: ValueNameWithQuestionType, showHiddenQuestions: boolean, filterByRoundId: string) {
     // questionType available
     return !!question["questionType"]
     // shown / hidden condition

--- a/swiss/src/app/landsraad/landsraad.component.ts
+++ b/swiss/src/app/landsraad/landsraad.component.ts
@@ -26,6 +26,7 @@ export class LandsraadComponent implements OnInit {
   questionsConfig: FormGroup
   showHiddenQuestions: Observable<boolean>
   filterByRoundId: Observable<string>
+  votingRights: Observable<ValueName[]>
 
   constructor(private fb: FormBuilder, public db: AngularFireDatabase) { }
 
@@ -114,6 +115,22 @@ export class LandsraadComponent implements OnInit {
           })
           formattedRounds.push({ value: "", name: "- Žádné -" })
           return formattedRounds
+        }
+      )
+    )
+    this.votingRights = this.db.list("landsraad/votingRights").snapshotChanges().pipe(
+      map(
+        rightsSnapshots => {
+          let formattedRights = rightsSnapshots.map(rightRef => {
+            let right = rightRef.payload.val()
+            let key = rightRef.key
+            return {
+              value: key,
+              name: right["name"]
+            }
+          })
+          formattedRights.push({ value: "", name: "- Žádný -" })
+          return formattedRights
         }
       )
     )

--- a/swiss/src/app/landsraad/landsraad.component.ts
+++ b/swiss/src/app/landsraad/landsraad.component.ts
@@ -164,7 +164,6 @@ export class LandsraadComponent implements OnInit {
         }
       )
     }
-    // TODO clear out the form for new question
   }
 
   currentQuestionChanged(event) {

--- a/swiss/src/app/question-form/question-form.component.css
+++ b/swiss/src/app/question-form/question-form.component.css
@@ -1,0 +1,3 @@
+.question-form-buttons {
+    margin-bottom: 20px;
+}

--- a/swiss/src/app/question-form/question-form.component.css
+++ b/swiss/src/app/question-form/question-form.component.css
@@ -1,3 +1,51 @@
 .question-form-buttons {
     margin-bottom: 20px;
 }
+.question-text {
+    width: 450px;
+}
+
+.text-fields {
+    display: inline-flex;
+
+    .question-form-round-item {
+        width: 90px;
+        margin-right: 10px;
+    }
+
+    .question-form-delegate-item, .question-form-right-item {
+        width: 120px;
+        margin-right: 10px;
+    }
+
+    .question-form-item-question-type {
+        width: 200px;
+        margin-right: 10px;
+    }
+
+    .label {
+        font-weight: 400;
+        line-height: 1.125;
+        font-family: Verdana, sans-serif;
+        font-size: 12px;
+        top: -25px;
+        padding-top: 0.84375em;
+        color: rgba(255, 255, 255, 0.7);
+        left: 0;
+        width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        position: relative;
+    }
+
+    .value {
+        width: 100%;
+        height: 40px;
+        position: relative;
+        top: -20px;
+        line-height: 20px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+}

--- a/swiss/src/app/question-form/question-form.component.html
+++ b/swiss/src/app/question-form/question-form.component.html
@@ -1,13 +1,30 @@
-<form [formGroup]="questionForm" appFireForm [path]="path" (stateChange)="changeHandler($event)">
+<form [formGroup]="questionForm" class="question-form" appFireForm [path]="path" (stateChange)="changeHandler($event)">
+    <mat-form-field class="text">
+        <input matInput placeholder="Typ dekretu" type="text" formControlName="decretType" />
+    </mat-form-field>&nbsp;
     <mat-form-field class="text">
         <input matInput placeholder="Otázka" type="text" formControlName="name" />
     </mat-form-field>&nbsp;
+    <mat-form-field class="text">
+        <input matInput placeholder="Navrženo delegátem" type="text" formControlName="byDelegateId" readonly />
+    </mat-form-field>&nbsp;
+    <mat-form-field class="text">
+        <input matInput placeholder="Navrženo rodem" type="text" formControlName="byHouse" readonly />
+    </mat-form-field>&nbsp;
+    <mat-form-field class="text">
+        <input matInput placeholder="Navrženo v kole" type="text" formControlName="roundId" readonly />
+    </mat-form-field>&nbsp;
     <app-answer-form *ngFor="let path of answerPaths | async" [path]="path"></app-answer-form>
-     {{ state }} &nbsp;
-    <button mat-stroked-button color="accent" (click)="export()">
-        Export hlasů
-    </button>&nbsp;
-    <button mat-stroked-button color="accent" (click)="delete()">
-        Smazat
-    </button>
+    <div class="question-form-buttons">
+        {{ state }}&nbsp;
+        <mat-checkbox class="basic-checkbox" formControlName="hidden">
+            Otázka schovaná
+        </mat-checkbox>&nbsp;
+        <button mat-stroked-button color="accent" (click)="delete()">
+            Smazat
+        </button>&nbsp;
+        <button mat-stroked-button color="basic" (click)="export()">
+            Export hlasů
+        </button>
+    </div>
 </form>

--- a/swiss/src/app/question-form/question-form.component.html
+++ b/swiss/src/app/question-form/question-form.component.html
@@ -1,19 +1,27 @@
 <form [formGroup]="questionForm" class="question-form" appFireForm [path]="path" (stateChange)="changeHandler($event)">
-    <mat-form-field class="text">
-        <input matInput placeholder="Typ dekretu" type="text" formControlName="questionType" />
-    </mat-form-field>&nbsp;
-    <mat-form-field class="text">
+    <div class="text-fields">
+        <div class="question-form-item-question-type">
+            <div class="label">Typ dekretu</div>
+            <div class="value">{{ questionTypeFormatted }}</div>
+        </div>
+    </div>
+    <mat-form-field class="question-text">
         <input matInput placeholder="Otázka" type="text" formControlName="name" />
     </mat-form-field>&nbsp;
-    <mat-form-field class="text">
-        <input matInput placeholder="Navrženo delegátem" type="text" formControlName="byDelegateId" readonly />
-    </mat-form-field>&nbsp;
-    <mat-form-field class="text">
-        <input matInput placeholder="Navrženo rodem" type="text" formControlName="byVotingRightId" readonly />
-    </mat-form-field>&nbsp;
-    <mat-form-field class="text">
-        <input matInput placeholder="Navrženo v kole" type="text" formControlName="roundId" readonly />
-    </mat-form-field>&nbsp;
+    <div class="text-fields">
+        <div class="question-form-delegate-item">
+            <div class="label">Návrh delegátem</div>
+            <div class="value">{{ delegateName }}</div>
+        </div>
+        <div class="question-form-right-item">
+            <div class="label">Návrh rodem</div>
+            <div class="value">{{ votingRightName }}</div>
+        </div>
+        <div class="question-form-round-item">
+            <div class="label">Návrh v kole</div>
+            <div class="value">{{ roundName }}</div>
+        </div>
+    </div>
     <app-answer-form *ngFor="let path of answerPaths | async" [path]="path"></app-answer-form>
     <div class="question-form-buttons">
         {{ state }}&nbsp;

--- a/swiss/src/app/question-form/question-form.component.html
+++ b/swiss/src/app/question-form/question-form.component.html
@@ -1,6 +1,6 @@
 <form [formGroup]="questionForm" class="question-form" appFireForm [path]="path" (stateChange)="changeHandler($event)">
     <mat-form-field class="text">
-        <input matInput placeholder="Typ dekretu" type="text" formControlName="decretType" />
+        <input matInput placeholder="Typ dekretu" type="text" formControlName="questionType" />
     </mat-form-field>&nbsp;
     <mat-form-field class="text">
         <input matInput placeholder="Otázka" type="text" formControlName="name" />
@@ -9,7 +9,7 @@
         <input matInput placeholder="Navrženo delegátem" type="text" formControlName="byDelegateId" readonly />
     </mat-form-field>&nbsp;
     <mat-form-field class="text">
-        <input matInput placeholder="Navrženo rodem" type="text" formControlName="byHouse" readonly />
+        <input matInput placeholder="Navrženo rodem" type="text" formControlName="byVotingRightId" readonly />
     </mat-form-field>&nbsp;
     <mat-form-field class="text">
         <input matInput placeholder="Navrženo v kole" type="text" formControlName="roundId" readonly />

--- a/swiss/src/app/question-form/question-form.component.ts
+++ b/swiss/src/app/question-form/question-form.component.ts
@@ -33,14 +33,16 @@ export class QuestionFormComponent implements OnInit {
   answerPaths: Observable<string[]>
 
   ngOnInit() {
-    // TODO delegateId and roundId to names
+    // TODO delegateId, roundId and votingRightId to names
+    // TODO maybe already can be filtered in the parent component and the names just passed
+    // I should not use fireform for it but just display as text => even more calls for input value
     console.log("question form delegates")
     this.delegates.pipe(map(delegates => delegates.forEach(delegate => console.log(delegate)))).subscribe()
     console.log("question form rounds", this.rounds)
     this.questionForm = this.fb.group({
       name: [''],
       decretType: [""],
-      byHouse: [""],
+      byVotingRightId: [""],
       byDelegateId: [""],
       roundId: [""],
       hidden: [false],

--- a/swiss/src/app/question-form/question-form.component.ts
+++ b/swiss/src/app/question-form/question-form.component.ts
@@ -43,7 +43,6 @@ export class QuestionFormComponent implements OnInit {
 
   ngOnInit() {
     ALL_QUESTIONS.push(QUESTION_TYPE_HLAS_LANDSRAADU)
-    this.db.object(this.path).valueChanges().pipe().subscribe(question => console.log("question", question))
     this.questionForm = this.fb.group({
       name: ['']
     })
@@ -65,10 +64,7 @@ export class QuestionFormComponent implements OnInit {
             this.delegateName = delegate && delegate["name"]
           })
           this.votingRights.pipe().subscribe(rights => {
-            console.log("rights", rights)
-            console.log(question["byVotingRightId"])
             let right = rights.find(right => right["value"] === question["byVotingRightId"])
-            console.log("right", right)
             this.votingRightName = right && right["name"]
           })
           this.rounds.pipe().subscribe(rounds => {

--- a/swiss/src/app/question-form/question-form.component.ts
+++ b/swiss/src/app/question-form/question-form.component.ts
@@ -33,15 +33,16 @@ export class QuestionFormComponent implements OnInit {
   answerPaths: Observable<string[]>
 
   ngOnInit() {
+    this.db.object(this.path).valueChanges().pipe().subscribe(question => console.log("question", question))
     // TODO delegateId, roundId and votingRightId to names
     // TODO maybe already can be filtered in the parent component and the names just passed
     // I should not use fireform for it but just display as text => even more calls for input value
-    console.log("question form delegates")
-    this.delegates.pipe(map(delegates => delegates.forEach(delegate => console.log(delegate)))).subscribe()
-    console.log("question form rounds", this.rounds)
+    // format "Dekret type" and also show as text (no connection to fireform)
+    // only name will be editable
+    // TODO format width of the name so it is wider and questions are properly visible.
     this.questionForm = this.fb.group({
       name: [''],
-      decretType: [""],
+      questionType: [""],
       byVotingRightId: [""],
       byDelegateId: [""],
       roundId: [""],
@@ -65,6 +66,7 @@ export class QuestionFormComponent implements OnInit {
     this.dialog.open(DeleteConfirmDialogComponent, { data: this.questionForm.controls.name.value }).afterClosed().subscribe(
       result => {
         if (result) {
+          // TODO landsraad/votes warning permission errors: this worked: ".write": "auth.uid == 'swiss'",
           this.db.object("landsraad/answers/"+this.questionId).remove();
           this.db.object("landsraad/votes/"+this.questionId).remove();
           this.db.object(this.path).remove()

--- a/swiss/src/app/question-form/question-form.component.ts
+++ b/swiss/src/app/question-form/question-form.component.ts
@@ -45,7 +45,7 @@ export class QuestionFormComponent implements OnInit {
     ALL_QUESTIONS.push(QUESTION_TYPE_HLAS_LANDSRAADU)
     this.db.object(this.path).valueChanges().pipe().subscribe(question => console.log("question", question))
     this.questionForm = this.fb.group({
-      name: [''],
+      name: ['']
     })
     let paths = this.path.split("/")
     this.questionId = paths[2]

--- a/swiss/src/app/question-form/question-form.component.ts
+++ b/swiss/src/app/question-form/question-form.component.ts
@@ -6,6 +6,7 @@ import { ngxCsv } from 'ngx-csv';
 import { combineLatest, Observable } from 'rxjs';
 import { map, take, tap } from 'rxjs/operators';
 import { DeleteConfirmDialogComponent } from '../delete-confirm-dialog/delete-confirm-dialog.component';
+import { ValueName } from '../../../../common/config';
 
 @Component({
   selector: 'app-question-form',
@@ -17,19 +18,32 @@ export class QuestionFormComponent implements OnInit {
   constructor(private fb: FormBuilder, private db: AngularFireDatabase, private dialog: MatDialog) { }
 
   questionForm: FormGroup;
-
   state: string;
-
   questionId: string;
 
   @Input()
   path: string
 
+  @Input()
+  delegates: Observable<ValueName[]>
+
+  @Input()
+  rounds: Observable<ValueName[]>
+
   answerPaths: Observable<string[]>
 
   ngOnInit() {
+    // TODO delegateId and roundId to names
+    console.log("question form delegates")
+    this.delegates.pipe(map(delegates => delegates.forEach(delegate => console.log(delegate)))).subscribe()
+    console.log("question form rounds", this.rounds)
     this.questionForm = this.fb.group({
-      name: ['']
+      name: [''],
+      decretType: [""],
+      byHouse: [""],
+      byDelegateId: [""],
+      roundId: [""],
+      hidden: [false],
     })
     let paths = this.path.split("/")
     this.questionId = paths[2]


### PR DESCRIPTION
Co bylo uděláno v tomto PR:
- umožněno filtrování otázek v Landsraad admin UI
- filtrovat lze podle kola nebo "schovaných" otázek
- do Landsraad admin UI přidáno víc metadat (návrh delegátem, rodem a v jakém kole, typ dekretu)

Print screen Landsraad admin UI (otázky):
![image](https://github.com/davidvavra/duna-valka-assassinu/assets/35541444/aa480869-85a3-4929-bacc-c0a35950a367)
