### PR TITLE
bugfix: bind checked of resultsShown checkbox to value of resultsShown

### DIFF
--- a/swiss/src/app/landsraad/landsraad.component.html
+++ b/swiss/src/app/landsraad/landsraad.component.html
@@ -30,7 +30,7 @@
                     </mat-option>
                 </mat-select>
             </mat-form-field>
-            <mat-checkbox class="basic-checkbox" checked="(resultsShown | async)" (change)="toggleVotingCheckbox($event)">
+            <mat-checkbox class="basic-checkbox" [checked]="resultsShown | async" (change)="toggleVotingCheckbox($event)">
                 Ukázat výsledky
             </mat-checkbox>
         </form>

--- a/swiss/src/app/landsraad/landsraad.component.ts
+++ b/swiss/src/app/landsraad/landsraad.component.ts
@@ -171,7 +171,6 @@ export class LandsraadComponent implements OnInit {
   }
 
   toggleVotingCheckbox(event) {
-    this.resultsShown = event.checked
     this.db.object("landsraad/votingConfig/resultsShown").set(event.checked)
   }
 


### PR DESCRIPTION
There were missing brackets which prevented to bind the actual value of the "resultsShown" on the init. After that the value has been changed by the "onClick" event (and the resultsShown has been displayed properly).